### PR TITLE
🩹 fix(cutefetch): Suppressed the xorg collection deprecation warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {

--- a/pkg/cutefetch/package.nix
+++ b/pkg/cutefetch/package.nix
@@ -4,7 +4,6 @@
   stdenvNoCC,
   fetchFromGitHub,
 }:
-
 let
   author = "cybardev";
   pname = "cutefetch";
@@ -38,8 +37,8 @@ stdenvNoCC.mkDerivation {
           [ ]
           ++ lib.optionals pkgs.stdenvNoCC.hostPlatform.isLinux [
             networkmanager
-            xorg.xprop
-            xorg.xdpyinfo
+            xprop
+            xdpyinfo
           ]
         )
       }


### PR DESCRIPTION
## Why have I made this PR?
On the latest nixpkgs versions, the xorg collection has been deprecated, and the individual packages are now available at the top level. Running cutefetch from this flake now generates warnings, so I've updated the cutefetch package declaration and bumped the nixpkgs version used by this flake.
## Acknowledgments
This commit upgrades nixpkgs to the latest unstable channel. As a result, some packages here might have been broken as a consequence, and flakes using this repository might also need to be updated.
This is my suggested fix, but I think it's worth discussing whether this change is necessary right now. I'm also fairly new to Nix and would be happy to be pointed to established conventions if this isn't the right approach.

